### PR TITLE
CommonJS support

### DIFF
--- a/src/angular-ladda.js
+++ b/src/angular-ladda.js
@@ -13,7 +13,7 @@
     define(['angular', 'ladda'], factory);
   } else if (typeof module !== 'undefined' && typeof module.exports === 'object') {
     // CommonJS support (for us webpack/browserify/ComponentJS folks)
-    module.exports = factory(require('angular'), require('ladda'));
+    module.exports = factory(window.angular, require('ladda'));
   } else {
     // in the case of no module loading system
     return factory(root.angular, root.Ladda);


### PR DESCRIPTION
Do not require angular, use window.angular instead.
This approach is more safety.

Assume you have in your project two version of angular, one installed via NPM and one stored locally (use case: part of your application needs IE8 support).
If you try to get angular with require('angular') you'll always get the latest version that installed via NPM.
I the other hand, if you use window.angular you'll get the pre loaded angular for the application.