### PR TITLE
update ladda dependency to keep it from crashing

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "LICENSE"
   ],
   "dependencies": {
-    "ladda": ">=0.9.8"
+    "ladda": ">=0.9.8 <2.0.0"
   },
   "peerDependencies": {
     "angular": ">=1.2.0 <2.0"


### PR DESCRIPTION
Updating packages will now crash ladda since it will load version 2.0.1. Since they don't work together well the dependency should be restricted.